### PR TITLE
Add backtrace for exceptions

### DIFF
--- a/advanced/main.py
+++ b/advanced/main.py
@@ -12,7 +12,7 @@ M. Holliday
 print('\n{lines}\n{:^40}\n{lines}\n'.format('Beep-Sat Demo',lines='-'*40))
 
 print('Initializing PyCubed Hardware...')
-import os, tasko
+import os, tasko, traceback
 from pycubed import cubesat
 
 # create asyncio object
@@ -50,12 +50,13 @@ try:
     # should run forever
     cubesat.tasko.run()
 except Exception as e:
-    print('FATAL ERROR: {}'.format(e))
+    formated_exception = traceback.format_exception(e, e, e.__traceback__)
+    print(formated_exception)
     try:
         # increment our NVM error counter
         cubesat.c_state_err+=1
         # try to log everything
-        cubesat.log('{},{},{}'.format(e,cubesat.c_state_err,cubesat.c_boot))
+        cubesat.log('{},{},{}'.format(formated_exception,cubesat.c_state_err,cubesat.c_boot))
     except:
         pass
 


### PR DESCRIPTION
The CircuitPython `traceback` core module formats backtraces, which make it easier to debug. Example log file looks like this:
```txt
14, Traceback (most recent call last):
  File "main.py", line 52, in <module>
  File "/lib/tasko/loop.py", line 293, in run
  File "/lib/tasko/loop.py", line 308, in _step
  File "/lib/tasko/loop.py", line 364, in _run_task
  File "/lib/tasko/loop.py", line 109, in _run_at_fixed_rate
  File "/lib/tasko/loop.py", line 259, in call_later
  File "Tasks/task_a.py", line 20, in main_task
  File "/lib/ftp.py", line 143, in receive_packet
TypeError: object with buffer protocol required
,255,254
```
If you aren't careful how you use it, traceback will do a soft restart before you are ready, but using e.__traceback__ fixed that:
<img width="1425" alt="Screen Shot 2022-04-17 at 4 08 21 PM" src="https://user-images.githubusercontent.com/41974521/163735661-85fc1689-e6b6-4ad4-8a75-ff656b30dc48.png">

