### PR TITLE
bug fixes and small improvements

### DIFF
--- a/advanced/Tasks/battery_task.py
+++ b/advanced/Tasks/battery_task.py
@@ -66,4 +66,6 @@ class task(Task):
                 # restart all tasks
                 for t in self.cubesat.scheduled_tasks:
                     self.cubesat.scheduled_tasks[t].start()
-
+        # otherwise stay in normal mode
+        else:
+            self.cubesat.powermode('normal')

--- a/advanced/cdh.py
+++ b/advanced/cdh.py
@@ -46,7 +46,7 @@ def shutdown(self,args):
 
 def query(self,args):
     self.debug('query: {}'.format(args))
-    self.cubesat.radio1.send(data=str(eval(args)))
+    self.cubesat.radio1.send(data=str(eval(args)), keep_listening=True)
 
 def exec_cmd(self,args):
     self.debug('exec: {}'.format(args))

--- a/advanced/lib/pycubed.py
+++ b/advanced/lib/pycubed.py
@@ -57,7 +57,7 @@ class Satellite:
         """
         Big init routine as the whole board is brought up.
         """
-        self.BOOTTIME= const(time.time())
+        self.BOOTTIME= const(time.monotonic())
         self.data_cache={}
         self.filenumbers={}
         self.vlowbatt=6.0

--- a/advanced/lib/pycubed_rfm9x.py
+++ b/advanced/lib/pycubed_rfm9x.py
@@ -717,6 +717,7 @@ class RFM9x:
             return (self._read_u8(_RH_RF95_REG_12_IRQ_FLAGS) & 0x40) >> 6
 
     async def await_rx(self,timeout=60):
+        self.listen()
         _t=time.monotonic()+timeout
         while not self.rx_done():
             if time.monotonic() < _t:


### PR DESCRIPTION
Hey @maholli!

A couple of small changes proposed based on our experience building, testing, and operating [Sapling Giganteum](https://saplingsat.org/Sapling-Giganteum-dfb8f0c853574b8bb27012101b4fb19c)

- call `cubesat.powermode` explicitly in the `battery_task.py`, otherwise its never set until after it cycles to low power and back. We failed a range test because of this, and corrected in our code.
- add an explicit call to `radio.listen()` in `radio.await_rx()` for expected behavior. We had an issue with our ground station transmitting commands without using `keep_listening=True`, and then using `radio.await_rx()` and not getting a response!. In general, I think we should opt for functions that are safer to use. 
- In the query command, also add a `keep_listening=True`—we were failing to successfully multi-command (using code similar to what is on dev-advanced-2) because of this.
- for consistency, use `time.monotonic` as the `BOOTTIME` reference (because we compare to this in `battery_task.py`)

Happy to add these to the other pycubed.py files around the pycubed org if they are accepted!