### PR TITLE
Implemented f strings and fixed some spelling

### DIFF
--- a/advanced/Tasks/battery_task.py
+++ b/advanced/Tasks/battery_task.py
@@ -20,7 +20,7 @@ class task(Task):
         else:
             comp_var = '<'
 
-        self.debug('{:.1f}V {} threshold: {:.1f}V'.format(vbatt,comp_var,self.cubesat.vlowbatt))
+        self.debug(f'{vbatt:.1f}V {comp_var} threshold: {self.cubesat.vlowbatt:.1f}V')
 
         ########### ADVANCED ###########
         # respond to a low power condition
@@ -40,9 +40,9 @@ class task(Task):
                 while time.monotonic() < _timer:
                     # sleep for half our remaining time
                     _sleeptime = self.timeout/10
-                    self.debug('sleeping for {}s'.format(_sleeptime),2)
+                    self.debug(f'sleeping for {_sleeptime}s', 2)
                     time.sleep(_sleeptime)
-                    self.debug('vbatt: {:.1f}V'.format(self.cubesat.battery_voltage),2)
+                    self.debug(f'vbatt: {self.cubesat.battery_voltage:.1f}V', 2)
                     vbatt=self.cubesat.battery_voltage
                     if vbatt > self.cubesat.vlowbatt:
                         self.debug('batteries above threshold',2)

--- a/advanced/Tasks/beacon_task.py
+++ b/advanced/Tasks/beacon_task.py
@@ -57,7 +57,8 @@ class task(Task):
             response = self.cubesat.radio1.receive(keep_listening=True,with_ack=ANTENNA_ATTACHED)
             if response is not None:
                 self.debug("packet received")
-                self.debug('msg: {}, RSSI: {}'.format(response,self.cubesat.radio1.last_rssi-137),2)
+                self.debug(f'msg: {response}, RSSI: {self.cubesat.radio1.last_rssi-137}', 2)
+
                 self.cubesat.c_gs_resp+=1
 
                 """
@@ -76,19 +77,19 @@ class task(Task):
                                 self.debug('command with args',2)
                                 try:
                                     cmd_args=response[6:] # arguments are everything after
-                                    self.debug('cmd args: {}'.format(cmd_args),2)
+                                    self.debug(f'cmd args: {cmd_args}', 2)
                                 except Exception as e:
-                                    self.debug('arg decoding error: {}'.format(e),2)
+                                    self.debug(f'arg decoding error: {e}', 2)
                             if cmd in cdh.commands:
                                 try:
                                     if cmd_args is None:
-                                        self.debug('running {} (no args)'.format(cdh.commands[cmd]))
+                                        self.debug(f'running {cdh.commands[cmd]} (no args)')
                                         self.cmd_dispatch[cdh.commands[cmd]](self)
                                     else:
-                                        self.debug('running {} (with args: {})'.format(cdh.commands[cmd],cmd_args))
+                                        self.debug(f'running {cdh.commands[cmd]} (with args: {cmd_args})')
                                         self.cmd_dispatch[cdh.commands[cmd]](self,cmd_args)
                                 except Exception as e:
-                                    self.debug('something went wrong: {}'.format(e))
+                                    self.debug(f'something went wrong: {e}')
                                     self.cubesat.radio1.send(str(e).encode())
                             else:
                                 self.debug('invalid command!')

--- a/advanced/Tasks/imu_task.py
+++ b/advanced/Tasks/imu_task.py
@@ -34,7 +34,7 @@ class task(Task):
         # print the readings with some fancy formatting
         self.debug('IMU readings (x,y,z)')
         for imu_type in self.cubesat.data_cache['imu']:
-            self.debug('{:>5} {}'.format(imu_type,self.cubesat.data_cache['imu'][imu_type]),2)
+            self.debug(f"{imu_type:>5} {self.cubesat.data_cache['imu'][imu_type]}", 2)
 
         # save data to the sd card, but only if we have a proper data file
         if self.data_file is not None:
@@ -44,7 +44,7 @@ class task(Task):
             # check if the file is getting bigger than we'd like
             if stat(self.data_file)[6] >= 256: # bytes
                 if SEND_DATA:
-                    print('\nSend IMU data file: {}'.format(self.data_file))
+                    print(f'\nSend IMU data file: {self.data_file}')
                     with open(self.data_file,'rb') as f:
                         chunk = f.read(64) # each IMU readings is 64 bytes when encoded
                         while chunk:
@@ -55,7 +55,7 @@ class task(Task):
                     print('finished\n')
                 else:
                     # print the unpacked data from the file
-                    print('\nPrinting IMU data file: {}'.format(self.data_file))
+                    print(f'\nPrinting IMU data file: {self.data_file}')
                     with open(self.data_file,'rb') as f:
                         while True:
                             try: print('\t',msgpack.unpack(f))

--- a/advanced/Tasks/template_task.py
+++ b/advanced/Tasks/template_task.py
@@ -37,8 +37,9 @@ class Task:
         """
         if level==1:
             print('{:>30} {}'.format('['+co(msg=self.name,color=self.color)+']',msg))
+            print(f'[{co(msg=self.name,color=self.color):>30}] {msg}')
         else:
-            print('{}{}'.format('\t   └── ',msg))
+            print(f'\t   └── {msg}')
 
     async def main_task(self, *args, **kwargs):
         """

--- a/advanced/Tasks/test_task.py
+++ b/advanced/Tasks/test_task.py
@@ -10,6 +10,6 @@ class task(Task):
     schedule_later = True
 
     async def main_task(self):
-        self.debug('test start: {}'.format(time.monotonic()))
+        self.debug(f'test start: {time.monotonic()}')
         await self.cubesat.tasko.sleep(10)
-        self.debug('test stop: {}'.format(time.monotonic()))
+        self.debug(f'test stop: {time.monotonic()}')

--- a/advanced/Tasks/time_task.py
+++ b/advanced/Tasks/time_task.py
@@ -11,6 +11,6 @@ class task(Task):
 
     async def main_task(self):
         t_since_boot = time.monotonic() - self.cubesat.BOOTTIME
-        self.debug('{:.3f}s since boot'.format(t_since_boot))
+        self.debug(f'{t_since_boot:.3f}s since boot')
 
 

--- a/advanced/cdh.py
+++ b/advanced/cdh.py
@@ -45,11 +45,11 @@ def shutdown(self,args):
             time.sleep(100000)
 
 def query(self,args):
-    self.debug('query: {}'.format(args))
+    self.debug(f'query: {args}')
     self.cubesat.radio1.send(data=str(eval(args)), keep_listening=True)
 
 def exec_cmd(self,args):
-    self.debug('exec: {}'.format(args))
+    self.debug(f'exec: {args}')
     exec(args)
 
 

--- a/advanced/lib/pycubed.py
+++ b/advanced/lib/pycubed.py
@@ -306,12 +306,12 @@ class Satellite:
         if self.hardware['SDcard']:
             with open(self.logfile, "a+") as f:
                 t=int(time.monotonic())
-                f.write('{}, {}\n'.format(t,msg))
+                f.write(f'{t}, {msg}\n')
 
     def print_file(self,filedir=None,binary=False):
         if filedir==None:
             return
-        print('\n--- Printing File: {} ---'.format(filedir))
+        print(f'\n--- Printing File: {filedir} ---')
         if binary:
             with open(filedir, "rb") as file:
                 print(file.read())
@@ -376,16 +376,16 @@ class Satellite:
             n=0
             _folder=substring[:substring.rfind('/')+1]
             _file=substring[substring.rfind('/')+1:]
-            print('Creating new file in directory: /sd{} with file prefix: {}'.format(_folder,_file))
+            print(f'Creating new file in directory: /sd{_folder} with file prefix: {_file}')
             try: chdir('/sd'+_folder)
             except OSError:
-                print('Directory {} not found. Creating...'.format(_folder))
+                print(f'Directory {_folder} not found. Creating...')
                 try: mkdir('/sd'+_folder)
                 except Exception as e:
                     print(e)
                     return None
             for i in range(0xFFFF):
-                ff='/sd{}{}{:05}.txt'.format(_folder,_file,(n+i)%0xFFFF)
+                ff=f'/sd{_folder}{_file}{(n+i)%0xFFFF:05}.txt'
                 try:
                     if n is not None:
                         stat(ff)
@@ -417,7 +417,8 @@ class Satellite:
         # convert duty cycle % into 16-bit fractional up time
         dtycycl=int((dutycycle/100)*(0xFFFF))
         print('----- BURN WIRE CONFIGURATION -----')
-        print('\tFrequency of: {}Hz\n\tDuty cycle of: {}% (int:{})\n\tDuration of {}sec'.format(freq,(100*dtycycl/0xFFFF),dtycycl,duration))
+        print(f'\tFrequency of: {freq}Hz\n\tDuty cycle of: {(100*dtycycl/0xFFFF)}% (int:{dtycycl})\n\tDuration of {duration}sec')
+        
         # create our PWM object for the respective pin
         # not active since duty_cycle is set to 0 (for now)
         if '1' in burn_num:

--- a/advanced/main.py
+++ b/advanced/main.py
@@ -31,7 +31,7 @@ for file in os.listdir('Tasks'):
         continue
 
     # auto-magically import the task file
-    exec('import Tasks.{}'.format(file))
+    exec(f'import Tasks.{file}')
     # create a helper object for scheduling the task
     task_obj=eval('Tasks.'+file).task(cubesat)
 
@@ -50,13 +50,13 @@ try:
     # should run forever
     cubesat.tasko.run()
 except Exception as e:
-    formated_exception = traceback.format_exception(e, e, e.__traceback__)
-    print(formated_exception)
+    formatted_exception = traceback.format_exception(e, e, e.__traceback__)
+    print(formatted_exception)
     try:
         # increment our NVM error counter
         cubesat.c_state_err+=1
         # try to log everything
-        cubesat.log('{},{},{}'.format(formated_exception,cubesat.c_state_err,cubesat.c_boot))
+        cubesat.log(f'{formatted_exception},{cubesat.c_state_err},{cubesat.c_boot}')
     except:
         pass
 

--- a/basic/Tasks/battery_task.py
+++ b/basic/Tasks/battery_task.py
@@ -17,4 +17,4 @@ class task(Task):
         else:
             comp_var = '<'
 
-        self.debug('{:.1f}V {} threshold: {:.1f}V'.format(vbatt,comp_var,self.cubesat.vlowbatt))
+        self.debug(f'{vbatt:.1f}V {comp_var} threshold: {self.cubesat.vlowbatt:.1f}V')

--- a/basic/Tasks/beacon_task.py
+++ b/basic/Tasks/beacon_task.py
@@ -37,7 +37,7 @@ class task(Task):
             response = self.cubesat.radio1.receive(keep_listening=False)
             if response is not None:
                 self.debug("packet received")
-                self.debug('msg: {}, RSSI: {}'.format(response,self.cubesat.radio1.last_rssi-137),2)
+                self.debug(f'msg: {response}, RSSI: {self.cubesat.radio1.last_rssi-137}', 2)
                 self.cubesat.c_gs_resp+=1
         else:
             self.debug('no messages')

--- a/basic/Tasks/imu_task.py
+++ b/basic/Tasks/imu_task.py
@@ -22,7 +22,7 @@ class task(Task):
         # print the readings with some fancy formatting
         self.debug('IMU readings (x,y,z)')
         for imu_type in self.cubesat.data_cache['imu']:
-            self.debug('{:>5} {}'.format(imu_type,self.cubesat.data_cache['imu'][imu_type]),2)
+            self.debug(f"{imu_type:>5} {self.cubesat.data_cache['imu'][imu_type]}",2)
 
 
 

--- a/basic/Tasks/template_task.py
+++ b/basic/Tasks/template_task.py
@@ -36,9 +36,9 @@ class Task:
 
         """
         if level==1:
-            print('{:>30} {}'.format('['+co(msg=self.name,color=self.color)+']',msg))
+            print(f'[{co(msg=self.name,color=self.color):>30}] {msg}')
         else:
-            print('{}{}'.format('\t   └── ',msg))
+            print(f'\t   └── {msg}')
 
     async def main_task(self, *args, **kwargs):
         """

--- a/basic/Tasks/test_task.py
+++ b/basic/Tasks/test_task.py
@@ -10,6 +10,6 @@ class task(Task):
     schedule_later = True
 
     async def main_task(self):
-        self.debug('test start: {}'.format(time.monotonic()))
+        self.debug(f'test start: {time.monotonic()}')
         await self.cubesat.tasko.sleep(10)
-        self.debug('test stop: {}'.format(time.monotonic()))
+        self.debug(f'test stop: {time.monotonic()}')

--- a/basic/Tasks/time_task.py
+++ b/basic/Tasks/time_task.py
@@ -11,6 +11,6 @@ class task(Task):
 
     async def main_task(self):
         t_since_boot = time.monotonic() - self.cubesat.BOOTTIME
-        self.debug('{:.3f}s since boot'.format(t_since_boot))
+        self.debug(f'{t_since_boot:.3f}s since boot')
 
 

--- a/basic/lib/pycubed.py
+++ b/basic/lib/pycubed.py
@@ -306,12 +306,12 @@ class Satellite:
         if self.hardware['SDcard']:
             with open(self.logfile, "a+") as f:
                 t=int(time.monotonic())
-                f.write('{}, {}\n'.format(t,msg))
+                f.write(f'{t}, {msg}\n')
 
     def print_file(self,filedir=None,binary=False):
         if filedir==None:
             return
-        print('\n--- Printing File: {} ---'.format(filedir))
+        print(f'\n--- Printing File: {filedir} ---')
         if binary:
             with open(filedir, "rb") as file:
                 print(file.read())
@@ -376,16 +376,16 @@ class Satellite:
             n=0
             _folder=substring[:substring.rfind('/')+1]
             _file=substring[substring.rfind('/')+1:]
-            print('Creating new file in directory: /sd{} with file prefix: {}'.format(_folder,_file))
+            print(f'Creating new file in directory: /sd{_folder} with file prefix: {_file}')
             try: chdir('/sd'+_folder)
             except OSError:
-                print('Directory {} not found. Creating...'.format(_folder))
+                print(f'Directory {_folder} not found. Creating...')
                 try: mkdir('/sd'+_folder)
                 except Exception as e:
                     print(e)
                     return None
             for i in range(0xFFFF):
-                ff='/sd{}{}{:05}.txt'.format(_folder,_file,(n+i)%0xFFFF)
+                ff=f'/sd{_folder}{_file}{(n+i)%0xFFFF:05}.txt'
                 try:
                     if n is not None:
                         stat(ff)
@@ -417,7 +417,7 @@ class Satellite:
         # convert duty cycle % into 16-bit fractional up time
         dtycycl=int((dutycycle/100)*(0xFFFF))
         print('----- BURN WIRE CONFIGURATION -----')
-        print('\tFrequency of: {}Hz\n\tDuty cycle of: {}% (int:{})\n\tDuration of {}sec'.format(freq,(100*dtycycl/0xFFFF),dtycycl,duration))
+        print(f'\tFrequency of: {freq}Hz\n\tDuty cycle of: {(100*dtycycl/0xFFFF)}% (int:{dtycycl})\n\tDuration of {duration}sec')
         # create our PWM object for the respective pin
         # not active since duty_cycle is set to 0 (for now)
         if '1' in burn_num:

--- a/basic/main.py
+++ b/basic/main.py
@@ -27,7 +27,7 @@ for file in os.listdir('Tasks'):
         continue
 
     # auto-magically import the task file
-    exec('import Tasks.{}'.format(file))
+    exec(f'import Tasks.{file}')
     # create a helper object for scheduling the task
     task_obj=eval('Tasks.'+file).task(cubesat)
 


### PR DESCRIPTION
I changed all of the string.format()'s to f-strings to make the code cleaner and easier to read. F-strings are also faster than string.format() according to [this RealPython article](https://realpython.com/python-f-strings/#:~:text=PEP%208.-,Speed,faster%20than%20str.format().%20A%20special%20BUILD_STRING%20opcode%20was%20introduced.,-Remove%20ads). Further details on f-strings can be seen in [this PEPS Python documentation](https://peps.python.org/pep-0498/#abstract). Though it does not affect the code's functionality that much, it makes the code more concise, easier to read, and more versatile, which can help Python beginners.

Note that f-strings require Python 3.6 or newer to run, but I feel like it is safe to assume that most people are running a compatible version of Python.  